### PR TITLE
Upgrade session manager to Tomcat 9.

### DIFF
--- a/doc/modules/ROOT/pages/index.adoc
+++ b/doc/modules/ROOT/pages/index.adoc
@@ -37,7 +37,7 @@ To configure session replication, let's first add some dependencies to the pom.x
 ----
 <dependency>
     <groupId>com.hazelcast</groupId>
-    <artifactId>hazelcast-tomcat85-sessionmanager</artifactId>
+    <artifactId>hazelcast-tomcat9-sessionmanager</artifactId>
     <version>${hazelcast-tomcat-sessionmanager.version}</version>
 </dependency>
 <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@
         </dependency>
         <dependency>
             <groupId>com.hazelcast</groupId>
-            <artifactId>hazelcast-tomcat85-sessionmanager</artifactId>
+            <artifactId>hazelcast-tomcat9-sessionmanager</artifactId>
             <version>${hazelcast-tomcat-sessionmanager.version}</version>
         </dependency>
         <dependency>


### PR DESCRIPTION
Although `hazelcast-session-manager85` is compatible with Tomcat 9, it would be better to keep it consistent with the parent's Tomcat version (see Tomcat 9.0.38 in use: https://search.maven.org/artifact/org.springframework.boot/spring-boot-dependencies/2.3.4.RELEASE/pom).